### PR TITLE
Maryia/fix: CompareAccountsModal Add button to open real account needed modal

### DIFF
--- a/packages/cfd/src/Containers/cfd-dashboard.tsx
+++ b/packages/cfd/src/Containers/cfd-dashboard.tsx
@@ -556,6 +556,7 @@ const CFDDashboard = (props: TCFDDashboardProps) => {
                                 platform={platform}
                                 is_demo_tab={is_demo_tab}
                                 openPasswordModal={openRealPasswordModal}
+                                is_real_enabled={is_real_enabled}
                             />
                             <JurisdictionModal
                                 platform={platform}

--- a/packages/cfd/src/Containers/cfd-dbvi-onboarding.tsx
+++ b/packages/cfd/src/Containers/cfd-dbvi-onboarding.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { DesktopWrapper, Loading, MobileDialog, MobileWrapper, Modal, UILoader } from '@deriv/components';
+import { DesktopWrapper, MobileDialog, MobileWrapper, Modal, UILoader } from '@deriv/components';
 import { localize } from '@deriv/translations';
 import RootStore from 'Stores/index';
 import { PoiPoaSubmitted } from '@deriv/account';
@@ -33,19 +33,17 @@ const CFDDbViOnBoarding = ({
     mt5_login_list,
     toggleJurisdictionModal,
 }: TVerificationModalProps) => {
-    const [is_loading, setIsLoading] = React.useState(true);
     const [showSubmittedModal, setShowSubmittedModal] = React.useState(false);
     const handleOpenJurisditionModal = () => {
         toggleCFDVerificationModal();
         toggleJurisdictionModal();
     };
-    const getAccountStausFromAPI = () => {
+    const getAccountStatusFromAPI = () => {
         WS.authorized.getAccountStatus().then((response: AccountStatusResponse) => {
             const { get_account_status } = response;
             if (get_account_status?.authentication) {
                 const identity_status = get_account_status?.authentication?.identity?.status;
                 const document_status = get_account_status?.authentication?.document?.status;
-                setIsLoading(false);
                 if (
                     (identity_status === 'pending' || identity_status === 'verified') &&
                     (document_status === 'pending' || document_status === 'verified')
@@ -59,8 +57,7 @@ const CFDDbViOnBoarding = ({
     };
     React.useEffect(() => {
         if (is_cfd_verification_modal_visible) {
-            setIsLoading(true);
-            getAccountStausFromAPI();
+            getAccountStatusFromAPI();
         }
     }, [is_cfd_verification_modal_visible]);
 
@@ -76,7 +73,7 @@ const CFDDbViOnBoarding = ({
                     toggleModal={toggleCFDVerificationModal}
                     height='700px'
                     width='996px'
-                    onMount={() => getAccountStausFromAPI()}
+                    onMount={() => getAccountStatusFromAPI()}
                     exit_classname='cfd-modal--custom-exit'
                 >
                     {showSubmittedModal ? (

--- a/packages/cfd/src/Containers/compare-accounts-modal.tsx
+++ b/packages/cfd/src/Containers/compare-accounts-modal.tsx
@@ -27,10 +27,12 @@ type TCompareAccountsModalProps = TCompareAccountsReusedProps & {
     is_loading: boolean;
     is_eu: boolean;
     is_eu_country: boolean;
+    is_real_enabled: boolean;
     residence: string;
     is_demo_tab: boolean;
     toggleCompareAccounts: () => void;
     openPasswordModal: (account_type: TOpenAccountTransferMeta) => void;
+    openDerivRealAccountNeededModal: () => void;
 };
 
 const CompareAccountsModal = ({
@@ -43,11 +45,13 @@ const CompareAccountsModal = ({
     is_eu,
     is_uk,
     is_eu_country,
+    is_real_enabled,
     platform,
     residence,
     is_demo_tab,
     toggleCompareAccounts,
     openPasswordModal,
+    openDerivRealAccountNeededModal,
 }: TCompareAccountsModalProps) => {
     const show_eu_related = (is_logged_in && is_eu) || (!is_logged_in && is_eu_country);
     const is_dxtrade = platform && platform === CFD_PLATFORMS.DXTRADE;
@@ -120,9 +124,12 @@ const CompareAccountsModal = ({
                             ) : (
                                 <DMT5CompareModalContent
                                     is_logged_in={is_logged_in}
+                                    openDerivRealAccountNeededModal={openDerivRealAccountNeededModal}
                                     openPasswordModal={openPasswordModal}
                                     is_demo_tab={is_demo_tab}
                                     show_eu_related={show_eu_related}
+                                    is_real_enabled={is_real_enabled}
+                                    toggleCompareAccounts={toggleCompareAccounts}
                                 />
                             )}
                         </Modal>
@@ -149,9 +156,12 @@ const CompareAccountsModal = ({
                             ) : (
                                 <DMT5CompareModalContent
                                     is_logged_in={is_logged_in}
+                                    openDerivRealAccountNeededModal={openDerivRealAccountNeededModal}
                                     openPasswordModal={openPasswordModal}
                                     is_demo_tab={is_demo_tab}
                                     show_eu_related={show_eu_related}
+                                    is_real_enabled={is_real_enabled}
+                                    toggleCompareAccounts={toggleCompareAccounts}
                                 />
                             )}
                         </MobileDialog>
@@ -174,4 +184,5 @@ export default connect(({ modules, ui, client }: RootStore) => ({
     landing_companies: client.landing_companies,
     residence: client.residence,
     toggleCompareAccounts: modules.cfd.toggleCompareAccountsModal,
+    openDerivRealAccountNeededModal: ui.openDerivRealAccountNeededModal,
 }))(CompareAccountsModal);

--- a/packages/cfd/src/Containers/mt5-compare-table-content.tsx
+++ b/packages/cfd/src/Containers/mt5-compare-table-content.tsx
@@ -226,8 +226,18 @@ const DMT5CompareModalContent = ({
     const available_accounts_keys = trading_platform_available_accounts.map(
         account => `${account.market_type === 'gaming' ? 'synthetic' : account.market_type}_${account.shortcode}`
     );
-    const synthetic_accounts_count = available_accounts_keys.filter(key => key.startsWith('synthetic')).length;
-    const financial_accounts_count = available_accounts_keys.filter(key => key.startsWith('financial')).length;
+    const logged_out_available_accounts_count = show_eu_related ? 1 : 6;
+    const available_accounts_count = is_logged_in
+        ? available_accounts_keys.length
+        : logged_out_available_accounts_count;
+    const synthetic_accounts_count =
+        !is_logged_in && !show_eu_related
+            ? 2
+            : available_accounts_keys.filter(key => key.startsWith('synthetic')).length;
+    const financial_accounts_count =
+        !is_logged_in && !show_eu_related
+            ? 4
+            : available_accounts_keys.filter(key => key.startsWith('financial')).length || 1;
 
     const poa_status = authentication_status?.document_status;
     const poi_status = authentication_status?.identity_status;
@@ -253,6 +263,7 @@ const DMT5CompareModalContent = ({
     }, []);
 
     const getAvailableAccountsContent = (_content: TModalContentProps[]) => {
+        if (!is_logged_in) return _content;
         return _content.map(row_data => {
             const available_accounts_values = Object.entries(row_data.values).reduce(
                 (acc, [key, value]) => (available_accounts_keys.includes(key) ? { ...acc, [key]: value } : acc),
@@ -387,8 +398,8 @@ const DMT5CompareModalContent = ({
                 show_eu_related
                     ? 'cfd-real-compare-accounts-row-eu'
                     : classNames('cfd-real-compare-accounts__table-row--instruments', {
-                          [`cfd-real-compare-accounts__row-with-columns-count-${available_accounts_keys.length + 1}`]:
-                              available_accounts_keys.length < 6,
+                          [`cfd-real-compare-accounts__row-with-columns-count-${available_accounts_count + 1}`]:
+                              available_accounts_count < 6,
                       })
             }
         >
@@ -428,9 +439,8 @@ const DMT5CompareModalContent = ({
                         ? 'cfd-real-compare-accounts-row-eu'
                         : classNames('cfd-real-compare-accounts__table-row', {
                               'cfd-real-compare-accounts__table-row--leverage': is_leverage,
-                              [`cfd-real-compare-accounts__row-with-columns-count-${
-                                  available_accounts_keys.length + 1
-                              }`]: available_accounts_keys.length < 6,
+                              [`cfd-real-compare-accounts__row-with-columns-count-${available_accounts_count + 1}`]:
+                                  available_accounts_count < 6,
                           })
                 }
             >
@@ -499,7 +509,7 @@ const DMT5CompareModalContent = ({
                                         ? 'cfd-real-compare-accounts-row-eu'
                                         : classNames('cfd-real-compare-accounts__table-header', {
                                               [`cfd-real-compare-accounts__table-header-for-synthetic-${synthetic_accounts_count}-financial-${financial_accounts_count}`]:
-                                                  available_accounts_keys.length < 6,
+                                                  available_accounts_count < 6,
                                           })
                                 }
                             >
@@ -522,15 +532,15 @@ const DMT5CompareModalContent = ({
                                 <Row key={row.id} {...row} />
                             ))}
                         </Table.Body>
-                        {is_logged_in && (
+                        {
                             <Table.Row
                                 className={
                                     show_eu_related
                                         ? 'cfd-real-compare-accounts-row-eu columns-2'
                                         : classNames('cfd-real-compare-accounts__table-footer', {
                                               [`cfd-real-compare-accounts__row-with-columns-count-${
-                                                  available_accounts_keys.length + 1
-                                              }`]: available_accounts_keys.length < 6,
+                                                  available_accounts_count + 1
+                                              }`]: available_accounts_count < 6,
                                           })
                                 }
                             >
@@ -568,7 +578,7 @@ const DMT5CompareModalContent = ({
                                         </Table.Cell>
                                     ))}
                             </Table.Row>
-                        )}
+                        }
                     </Table>
                 </div>
             </div>


### PR DESCRIPTION
## Changes:

Please include a summary of the change and which issue is fixed below:
-   fixed CompareAccountsModal Add button to open real account needed modal when a user doesn't have a Deriv account
-   fixed CompareAccountsModal for logged-out case
-   refactoring

## When you need to add unit test

-   [ ] If this change disrupt current flow
-   [ ] If this change is adding new flow

## When you need to add integration test

-   [ ] If components from external libraries are being used to define the flow, e.g. @deriv/components
-   [ ] If it relies on a very specific set of props with no default behavior for the current component.

## Test coverage checklist (for reviewer)

-   [ ] Ensure utility / function has a test case 
-   [ ] Ensure all the tests are passing

## Type of change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
